### PR TITLE
Add Claude Code GitHub integration via AWS Bedrock

### DIFF
--- a/.github/claude-code.config.json
+++ b/.github/claude-code.config.json
@@ -1,0 +1,11 @@
+{
+  "mode": "code",
+  "customInstructions": "You are working on a Next.js todo application. When making changes via GitHub comments, ensure all code follows the project's conventions and runs the appropriate linting commands before committing.",
+  "memory": {
+    "enabled": true
+  },
+  "bedrock": {
+    "enabled": true,
+    "model": "anthropic.claude-3-5-sonnet-20241022-v2:0"
+  }
+}

--- a/.github/workflows/claude-pr.yml
+++ b/.github/workflows/claude-pr.yml
@@ -1,0 +1,128 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-pr:
+    if: |
+      (github.event_name == 'issue_comment' && 
+       contains(github.event.comment.body, '@claude') && 
+       github.event.issue.pull_request) ||
+      (github.event_name == 'pull_request_review_comment' && 
+       contains(github.event.comment.body, '@claude'))
+    
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      
+      - name: Install dependencies
+        run: bun install
+      
+      - name: Get PR details
+        id: pr-details
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER="${{ github.event.issue.number }}"
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          fi
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          
+          # Fetch PR information
+          gh pr checkout $PR_NUMBER
+          PR_BRANCH=$(gh pr view $PR_NUMBER --json headRefName -q .headRefName)
+          echo "pr_branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract Claude command
+        id: extract-command
+        run: |
+          COMMENT_BODY="${{ github.event.comment.body }}"
+          # Extract everything after @claude mention
+          CLAUDE_COMMAND=$(echo "$COMMENT_BODY" | sed -n 's/.*@claude\s*\(.*\)/\1/p')
+          echo "command=$CLAUDE_COMMAND" >> $GITHUB_OUTPUT
+      
+      - name: Setup AWS credentials for Bedrock
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      
+      - name: Run Claude Code with Bedrock
+        id: claude-run
+        run: |
+          # Create a temporary file for Claude's response
+          RESPONSE_FILE=$(mktemp)
+          
+          # Run claude with the command using Bedrock
+          npx @anthropic-ai/claude-code@latest "${{ steps.extract-command.outputs.command }}" > "$RESPONSE_FILE" 2>&1 || true
+          
+          # Read response
+          CLAUDE_RESPONSE=$(cat "$RESPONSE_FILE")
+          
+          # Save multiline response to output
+          echo "response<<EOF" >> $GITHUB_OUTPUT
+          echo "$CLAUDE_RESPONSE" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          # Clean up
+          rm -f "$RESPONSE_FILE"
+        env:
+          ANTHROPIC_USE_BEDROCK: "true"
+          ANTHROPIC_MODEL: "anthropic.claude-3-5-sonnet-20241022-v2:0"
+      
+      - name: Commit changes if any
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "Claude: Applied changes from comment
+            
+            Triggered by: @${{ github.event.comment.user.login }}
+            Command: ${{ steps.extract-command.outputs.command }}"
+            
+            git push origin HEAD:${{ steps.pr-details.outputs.pr_branch }}
+          fi
+      
+      - name: Post Claude response as comment
+        if: always()
+        run: |
+          # Create comment body with escaped backticks
+          cat > comment.md << 'COMMENT_EOF'
+          ## Claude Response
+          
+          ```
+          ${{ steps.claude-run.outputs.response }}
+          ```
+          
+          ---
+          *Triggered by @${{ github.event.comment.user.login }}*
+          COMMENT_EOF
+          
+          # Post comment
+          gh pr comment ${{ steps.pr-details.outputs.pr_number }} --body-file comment.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Next.js (v15.1.7) todo application using:
+- **Runtime**: Bun (v1.2.2)
+- **Authentication**: Clerk
+- **Database ORM**: Drizzle ORM
+- **Deployment**: Cloudflare Pages (via @cloudflare/next-on-pages)
+- **Styling**: Tailwind CSS
+
+## Key Commands
+
+```bash
+# Install dependencies
+bun install
+
+# Development server (runs on port 3002)
+bun dev
+
+# Build for production
+bun build
+
+# Start production server
+bun start
+
+# Run linting
+bun lint
+```
+
+## GitHub Integration
+
+This repository supports Claude Code integration via AWS Bedrock. You can mention `@claude` in PR comments to trigger automated code changes. The integration is configured to use Claude 3.5 Sonnet v2 via AWS Bedrock.
+
+## Architecture
+
+### Authentication
+- Clerk authentication is integrated via middleware at `/src/middleware.ts`
+- The middleware protects all routes except static assets and Next.js internals
+- API routes are always protected
+
+### TypeScript Configuration
+- Strict mode enabled
+- Path alias configured: `@/*` maps to `./src/*`
+- Target: ES2017 with modern DOM libraries
+
+### Project Structure
+- `/src/app/` - Next.js App Router pages and layouts
+- `/src/middleware.ts` - Clerk authentication middleware
+- `/public/` - Static assets (SVG icons)
+
+### Key Dependencies
+- **next**: 15.1.7 - React framework
+- **@clerk/nextjs**: 6.12.0 - Authentication
+- **drizzle-orm**: 0.39.3 - Database ORM
+- **@cloudflare/next-on-pages**: 1.13.7 - Cloudflare deployment adapter
+- **wrangler**: 3.109.2 - Cloudflare CLI tool
+
+### Development Notes
+- The project uses ESM modules (`"type": "module"` in package.json)
+- ESLint configured with Next.js recommended rules
+- No test framework currently configured

--- a/README.md
+++ b/README.md
@@ -8,3 +8,63 @@ Next.js(v15.1.7) + Clerk + Bun(v1.2.2)
 bun install
 bun dev
 ```
+
+## Claude GitHub Integration (via AWS Bedrock)
+
+This repository is configured to work with Claude through GitHub comments using AWS Bedrock. You can mention `@claude` in pull request comments to trigger Claude to make changes.
+
+### Setup
+
+To enable Claude integration via AWS Bedrock, you need to add the following secrets to your GitHub repository:
+
+1. **AWS_ACCESS_KEY_ID**: Your AWS Access Key ID
+   - Go to Settings → Secrets and variables → Actions
+   - Click "New repository secret"
+   - Name: `AWS_ACCESS_KEY_ID`
+
+2. **AWS_SECRET_ACCESS_KEY**: Your AWS Secret Access Key
+   - Name: `AWS_SECRET_ACCESS_KEY`
+
+3. **AWS_REGION**: AWS region where Bedrock is available (e.g., `us-east-1`)
+   - Name: `AWS_REGION`
+   - Common regions with Bedrock: `us-east-1`, `us-west-2`, `ap-northeast-1`
+
+### AWS IAM Permissions
+
+Your AWS user/role needs the following permissions for Bedrock:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"
+      ]
+    }
+  ]
+}
+```
+
+### Usage
+
+In any pull request, you can mention Claude in a comment:
+
+```
+@claude fix the TypeScript errors in this file
+```
+
+```
+@claude add error handling to the todo creation function
+```
+
+Claude will:
+1. Read your comment and understand the requested changes
+2. Make the necessary code modifications
+3. Commit the changes to the PR branch
+4. Post a response comment with what was done


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that triggers Claude Code on @claude mentions in PR comments
- Configure integration to use AWS Bedrock with Claude 3.5 Sonnet v2 model
- Add comprehensive setup documentation for AWS credentials and IAM permissions

## Test plan
- [ ] Verify GitHub Actions workflow triggers on @claude mentions
- [ ] Test AWS Bedrock authentication with configured secrets
- [ ] Validate Claude responses are posted as PR comments
- [ ] Confirm code changes are committed to PR branch

🤖 Generated with [Claude Code](https://claude.ai/code)